### PR TITLE
一定条件化で起きてしまうバグを修正

### DIFF
--- a/app/Models/ArticleTag.php
+++ b/app/Models/ArticleTag.php
@@ -99,9 +99,11 @@ class ArticleTag extends Model
             }
         }
 
+
         // 紐付けられていたタグすべて削除されたのならtag_id = nullのデータをついか
-        // もともと記事にタグがついていたか確認
-        if ($original[0]->getAttributes()["tag_id"] != null) {
+        // もともと記事にタグがついていたかと,
+        // 新しく紐付けられたタグが1つもないことを確認
+        if ($original[0]->getAttributes()["tag_id"] != null && empty($addedTagList)) {
             //もともとついていたタグがすべてはずされたか確認
             $isAllDeleted = array_diff($originalTagList,$deletedTagList);
             if (empty($isAllDeleted)) {

--- a/app/Models/BookMarkTag.php
+++ b/app/Models/BookMarkTag.php
@@ -97,8 +97,9 @@ class BookMarkTag extends Model
         }
 
         // 紐付けられていたタグすべて削除されたのならtag_id = nullのデータをついか
-        // もともとブックマークにタグがついていたか確認
-        if ($original[0]->getAttributes()["tag_id"] != null) {
+        // もともと記事にタグがついていたかと,
+        // 新しく紐付けられたタグが1つもないことを確認
+        if ($original[0]->getAttributes()["tag_id"] != null && empty($addedTagList)) {
             //もともとついていたタグがすべてはずされたか確認
             $isAllDeleted = array_diff($originalTagList,$deletedTagList);
             if (empty($isAllDeleted)) {


### PR DESCRIPTION
編集前につけたタグをすべてけして､別のタグをつけると｡
編集後にタグを1つもつけていない扱いになるバグを修正