### PR TITLE
タグをつけていない記事などをタグをつけていない状態で更新した時に起こるバグを修正

### DIFF
--- a/app/Repository/ArticleTagRepository.php
+++ b/app/Repository/ArticleTagRepository.php
@@ -103,7 +103,7 @@ class ArticleTagRepository
         if (is_null($originalTagList[0])) {
             //元の記事にタグはついてないし､新しくタグも設定されていない場合
             // この関数の処理を終わらせる
-            if (empty($updatedTagList)) {return true;}
+            if (is_null($updatedTagList[0])) {return true;}
             else {
                 // 更新前は記事にタグが1つもついていなくて
                 // 更新後にはタグが紐付けられていたら

--- a/app/Repository/BookMarkTagRepository.php
+++ b/app/Repository/BookMarkTagRepository.php
@@ -99,10 +99,11 @@ class BookMarkTagRepository
     //元のブックマークにタグがついてない場合の処理
     public  function procesOriginalBookMarkDoesNotHaveAnyTags($originalTagList,$bookMarkId,$updatedTagList)
     {
+        // 仕様としてタグをつけてない場合はtag_idにnullが入る<-超大事
         if (is_null($originalTagList[0])) {
             //元のブックマークにタグはついてないし､新しくタグも設定されていない場合
             // この関数の処理を終わらせる
-            if (empty($updatedTagList)) {return true;}
+            if (is_null($updatedTagList[0])) {return true;}
             else {
                 // 更新前はブックマークにタグが1つもついていなくて
                 // 更新後にはタグが紐付けられていたら


### PR DESCRIPTION
タグなし登録->タグなし更新->何かしらの更新->更新できない不具合発生
原因
タグなし更新のときに`tag_id` == nullのデータが削除されてしまうから
仕様
tag_idがnullだったらこの記事などはタグが一つもついてないものとする
