### PR TITLE
マークダウンに関するいろいろ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,9 +1762,9 @@
             }
         },
         "node_modules/marked": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-            "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
+            "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==",
             "dev": true,
             "bin": {
                 "marked": "bin/marked.js"
@@ -4070,9 +4070,9 @@
             }
         },
         "marked": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-            "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
+            "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==",
             "dev": true
         },
         "merge-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "dependencies": {
                 "@mdi/font": "^7.0.96",
+                "github-markdown-css": "^5.1.0",
                 "sanitize-html": "^2.7.3"
             },
             "devDependencies": {
@@ -1517,6 +1518,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/github-markdown-css": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-5.1.0.tgz",
+            "integrity": "sha512-QLtORwHHtUHhPMHu7i4GKfP6Vx5CWZn+NKQXe+cBhslY1HEt0CTEkP4d/vSROKV0iIJSpl4UtlQ16AD8C6lMug==",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/glob-parent": {
@@ -3883,6 +3892,11 @@
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.3"
             }
+        },
+        "github-markdown-css": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-5.1.0.tgz",
+            "integrity": "sha512-QLtORwHHtUHhPMHu7i4GKfP6Vx5CWZn+NKQXe+cBhslY1HEt0CTEkP4d/vSROKV0iIJSpl4UtlQ16AD8C6lMug=="
         },
         "glob-parent": {
             "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     },
     "dependencies": {
         "@mdi/font": "^7.0.96",
+        "github-markdown-css": "^5.1.0",
         "sanitize-html": "^2.7.3"
     }
 }

--- a/resources/js/Components/article/CompiledMarkDown.vue
+++ b/resources/js/Components/article/CompiledMarkDown.vue
@@ -5,6 +5,12 @@
 <script>
 import {marked} from 'marked';
 import sanitizeHtml from 'sanitize-html';
+
+// エンターで改行できるように設定
+marked.setOptions({
+    "breaks": true,
+    "gfm": true,
+});
 export default {
     props:{
         originalMarkDown:{
@@ -13,7 +19,9 @@ export default {
         },
     },
     methods: {compileMarkDown(){
-        return marked(sanitizeHtml(this.originalMarkDown))
+        const sanitized = sanitizeHtml(this.originalMarkDown)
+        const replaced  = sanitized.replaceAll(/\n(?=\n)/g, "\n<br>\n")
+        return marked(replaced)
     }},
 }
 </script>

--- a/resources/js/Components/article/CompiledMarkDown.vue
+++ b/resources/js/Components/article/CompiledMarkDown.vue
@@ -1,9 +1,10 @@
 <template>
-    <div class="CompiledMarkDown" v-html="compileMarkDown()"></div>
+    <div class="CompiledMarkDown markdown-body" v-html="compileMarkDown()"></div>
 </template>
 
 <script>
 import {marked} from 'marked';
+import githubMarkdownCss from 'github-markdown-css';
 import sanitizeHtml from 'sanitize-html';
 
 // エンターで改行できるように設定
@@ -27,36 +28,36 @@ export default {
 </script>
 
 <!-- なぜかわからないがscopedをつけたら中のh1タグなどが反応しない -->
-<style lang="scss">
+<style lang="scss" scoped>
 .CompiledMarkDown{
     padding-bottom: 2rem;
     word-break   :break-word;
     overflow-wrap:normal;
     list-style-position:inside;
-    h1,h2,h3,h4,h5{ margin:0.5rem 0; }
-    ul,ol{ margin:0.5rem 0; }
-    th,td {
-        padding:0.2rem;
-        border: solid 1px;
-    }
-    p{
-        code{
-            background-color: #e5e5e5;
-            color: #000000;
-            padding: 0 0.3rem;
-            margin: 0 0.3rem;
-        }
-    }
-    pre{
-        background-color: #364549;
-        color: #e3e3e3;
-        padding: 0.8rem;
-        // スクロールバー表示
-        overflow: auto;
-    }
-    table {
-        border-collapse:  collapse; /* セルの線を重ねる */
-        margin:0.5rem 0;
-    }
+//     h1,h2,h3,h4,h5{ margin:0.5rem 0; }
+//     ul,ol{ margin:0.5rem 0; }
+//     th,td {
+//         padding:0.2rem;
+//         border: solid 1px;
+//     }
+//     p{
+//         code{
+//             background-color: #e5e5e5;
+//             color: #000000;
+//             padding: 0 0.3rem;
+//             margin: 0 0.3rem;
+//         }
+//     }
+//     pre{
+//         background-color: #364549;
+//         color: #e3e3e3;
+//         padding: 0.8rem;
+//         // スクロールバー表示
+//         overflow: auto;
+//     }
+//     table {
+//         border-collapse:  collapse; /* セルの線を重ねる */
+//         margin:0.5rem 0;
+//     }
 }
 </style>


### PR DESCRIPTION
npmのライブラリを使ってgithubのマークダウンみたいなcssにする
エンターで改行できるようにした｡
空白行をエンターだけで追加できるようにした