### PR TITLE
詳しくはプルリクコメントへ

### DIFF
--- a/tests/Feature/Controller/ArticleController_UpdateTest.php
+++ b/tests/Feature/Controller/ArticleController_UpdateTest.php
@@ -14,6 +14,8 @@ use App\Models\ArticleTag;
 use App\Models\Tag;
 use App\Models\User;
 
+use App\Repository\ArticleTagRepository;
+
 // データベース関係で使う
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 
@@ -32,14 +34,28 @@ class ArticleController_UpdateTest extends TestCase
     // use WithoutMiddleware;
 
     private $user;
+    private $articleTagRepository;
 
     public function setup():void
     {
         parent::setUp();
         // ユーザーを用意
         $this->user = User::factory()->create();
+        $this->articleTagRepository = new ArticleTagRepository();
         // carbonの時間固定
         Carbon::setTestNow(Carbon::now());
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'ja';
+    }
+
+    public function update($id,$title,$body,$tagList)
+    {
+        return $this->actingAs($this->user)
+        ->put('/api/article/update/',[
+            'articleId'     => $id,
+            'articleTitle'  => $title,
+            'articleBody'   => $body,
+            'tagList' => $tagList,
+        ]);
     }
 
     // 期待
@@ -59,10 +75,7 @@ class ArticleController_UpdateTest extends TestCase
         $newTags = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag){
-            ArticleTag::create([
-                "article_id" => $article->id,
-                "tag_id"     => $tag->id
-            ]);
+            $this->articleTagRepository->store($tag->id,$article->id);
         }
 
 
@@ -122,10 +135,7 @@ class ArticleController_UpdateTest extends TestCase
         $newTags = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag){
-            ArticleTag::create([
-                "article_id" => $article->id,
-                "tag_id"     => $tag->id
-            ]);
+            $this->articleTagRepository->store($tag->id,$article->id);
         }
 
         $response = $this
@@ -186,10 +196,7 @@ class ArticleController_UpdateTest extends TestCase
         $tags    = Tag::factory()->count(4)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag){
-            ArticleTag::create([
-                "article_id" => $article->id,
-                "tag_id"     => $tag->id
-            ]);
+            $this->articleTagRepository->store($tag->id,$article->id);
         }
 
         $response = $this
@@ -255,10 +262,7 @@ class ArticleController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
-        ArticleTag::create([
-            "article_id" => $article->id,
-            "tag_id"     => null
-        ]);
+        $this->articleTagRepository->store(null,$article->id);
 
         $response = $this
         ->actingAs($this->user)
@@ -316,10 +320,7 @@ class ArticleController_UpdateTest extends TestCase
         $tags    = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag){
-            ArticleTag::create([
-                "article_id" => $article->id,
-                "tag_id"       => $tag->id
-            ]);
+            $this->articleTagRepository->store($tag->id,$article->id);
         }
 
         $response = $this
@@ -372,10 +373,7 @@ class ArticleController_UpdateTest extends TestCase
         // 記事などを作成
         $article = Article::factory()->create(['user_id' => $this->user->id]);
 
-        ArticleTag::create([
-            "article_id" => $article->id,
-            "tag_id"     => null
-        ]);
+        $this->articleTagRepository->store(null,$article->id);
 
         // 更新
         $response = $this
@@ -435,10 +433,7 @@ class ArticleController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
-        ArticleTag::create([
-            "article_id" => $article->id,
-            "tag_id"     => null
-        ]);
+        $this->articleTagRepository->store(null,$article->id);
 
         // 更新
         $response = $this
@@ -508,10 +503,7 @@ class ArticleController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
-        ArticleTag::create([
-            "article_id" => $article->id,
-            "tag_id"     => null
-        ]);
+        $this->articleTagRepository->store(null,$article->id);
 
         // 更新
         $response = $this
@@ -581,10 +573,7 @@ class ArticleController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(4)->create(['user_id' => $this->user->id]);
 
-        ArticleTag::create([
-            "article_id" => $article->id,
-            "tag_id"     => null
-        ]);
+        $this->articleTagRepository->store(null,$article->id);
 
         // 更新
         $response = $this
@@ -662,10 +651,7 @@ class ArticleController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(4)->create(['user_id' => $this->user->id]);
 
-        ArticleTag::create([
-            "article_id" => $article->id,
-            "tag_id"     => $tags[0]->id
-        ]);
+        $this->articleTagRepository->store($tags[0]->id,$article->id);
 
         // 更新
         $response = $this
@@ -733,10 +719,7 @@ class ArticleController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
-        ArticleTag::create([
-            "article_id" => $article->id,
-            "tag_id"       => $tags[0]->id,
-        ]);
+        $this->articleTagRepository->store($tags[0]->id,$article->id);
 
         // 更新
         $response = $this
@@ -809,10 +792,7 @@ class ArticleController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
-        ArticleTag::create([
-            "article_id" => $article->id,
-            "tag_id"       => $tags[0]->id
-        ]);
+        $this->articleTagRepository->store($tags[0]->id,$article->id);
 
         // 更新
         $response = $this
@@ -885,35 +865,16 @@ class ArticleController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(4)->create(['user_id' => $this->user->id]);
 
-        ArticleTag::create([
-            "article_id" => $article->id,
-            "tag_id"     => $tags[0]->id
-        ]);
+        $this->articleTagRepository->store($tags[0]->id,$article->id);
 
         // 更新
-        $response = $this
-        ->actingAs($this->user)
-        ->withSession(['test' => 'test'])
-        ->put('/api/article/update/',[
-            'articleId'     => $article->id,
-            'articleTitle'  => "更新",
-            'articleBody'    => "更新" ,
-            'tagList' => [$tags[1]->id],
-        ]);
+        $response = $this->update($article->id,"更新","更新",[$tags[1]->id]);
 
         // ステータス
         $response->assertStatus(200);
 
         // 再度更新
-        $response = $this
-        ->actingAs($this->user)
-        ->withSession(['test' => 'test'])
-        ->put('/api/article/update/',[
-            'articleId'     => $article->id,
-            'articleTitle'  => "再度更新",
-            'articleBody'    => "再度更新" ,
-            'tagList' => [$tags[2]->id],
-        ]);
+        $response = $this->update($article->id,"再度更新","再度更新",[$tags[2]->id]);
 
         // ステータス
         $response->assertStatus(200);
@@ -963,10 +924,7 @@ class ArticleController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(4)->create(['user_id' => $this->user->id]);
 
-        ArticleTag::create([
-            "article_id" => $article->id,
-            "tag_id"     => $tags[0]->id
-        ]);
+        $this->articleTagRepository->store($tags[0]->id,$article->id);
 
         // 更新
         $response = $this

--- a/tests/Feature/Controller/ArticleTransitionControllerTest.php
+++ b/tests/Feature/Controller/ArticleTransitionControllerTest.php
@@ -12,6 +12,8 @@ use App\Models\Article;
 use App\Models\ArticleTag;
 use App\Http\Controllers\ArticleTransitionController;
 
+use App\Repository\ArticleTagRepository;
+
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 use Carbon\Carbon;
@@ -26,6 +28,7 @@ class ArticleTransitionControllerTest extends TestCase
 
     private $user;
     private $controller;
+    private $articleTagRepository;
 
     public function setup():void
     {
@@ -33,6 +36,8 @@ class ArticleTransitionControllerTest extends TestCase
         // ユーザーを用意
         $this->user = User::factory()->create();
         $this->controller = new ArticleTransitionController();
+        $this->articleTagRepository = new ArticleTagRepository();
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'ja';
     }
 
     //自分でもいまいちなテストだと思う(他のテストもだけど)
@@ -53,10 +58,7 @@ class ArticleTransitionControllerTest extends TestCase
         $tags = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag) {
-            ArticleTag::create([
-                'article_id' => $article->id,
-                'tag_id'     => $tag->id,
-            ]);
+            $this->articleTagRepository->store($tag->id,$article->id);
         }
 
         $response = $this
@@ -82,10 +84,7 @@ class ArticleTransitionControllerTest extends TestCase
         $article = Article::factory()->create(['user_id' => $this->user->id]);
 
         // タグを登録
-        ArticleTag::create([
-            'article_id' => $article->id,
-            'tag_id'     => null,
-        ]);
+        $this->articleTagRepository->store(null,$article->id);
 
         $response = $this
         ->actingAs($this->user)
@@ -117,10 +116,7 @@ class ArticleTransitionControllerTest extends TestCase
         $tags = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag) {
-            ArticleTag::create([
-                'article_id' => $article->id,
-                'tag_id'     => $tag->id,
-            ]);
+            $this->articleTagRepository->store($tag->id,$article->id);
         }
 
         //削除
@@ -155,10 +151,7 @@ class ArticleTransitionControllerTest extends TestCase
         $tags = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag) {
-            ArticleTag::create([
-                'article_id' => $article->id,
-                'tag_id'     => $tag->id,
-            ]);
+            $this->articleTagRepository->store($tag->id,$article->id);
         }
 
         $response = $this
@@ -190,10 +183,7 @@ class ArticleTransitionControllerTest extends TestCase
         $tags = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag) {
-            ArticleTag::create([
-                'article_id' => $article->id,
-                'tag_id'     => $tag->id,
-            ]);
+            $this->articleTagRepository->store($tag->id,$article->id);
         }
 
         $response = $this
@@ -225,10 +215,7 @@ class ArticleTransitionControllerTest extends TestCase
         $tags = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag) {
-            ArticleTag::create([
-                'article_id' => $article->id,
-                'tag_id'     => $tag->id,
-            ]);
+            $this->articleTagRepository->store($tag->id,$article->id);
         }
 
         //削除
@@ -265,10 +252,7 @@ class ArticleTransitionControllerTest extends TestCase
         $tags = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag) {
-            ArticleTag::create([
-                'article_id' => $article->id,
-                'tag_id'     => $tag->id,
-            ]);
+            $this->articleTagRepository->store($tag->id,$article->id);
         }
 
         $response = $this
@@ -289,10 +273,7 @@ class ArticleTransitionControllerTest extends TestCase
     {
         $article = Article::factory()->create(['user_id' => $this->user->id]);
 
-        ArticleTag::create([
-            'article_id' => $article->id,
-            'tag_id'     => null,
-        ]);
+        $this->articleTagRepository->store(null,$article->id);
 
         $response = $this
         ->actingAs($this->user)

--- a/tests/Feature/Controller/BookMarkController_UpdateTest.php
+++ b/tests/Feature/Controller/BookMarkController_UpdateTest.php
@@ -14,6 +14,8 @@ use App\Models\BookMarkTag;
 use App\Models\Tag;
 use App\Models\User;
 
+use App\Repository\BookMarkTagRepository;
+
 // データベース関係で使う
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 
@@ -32,12 +34,16 @@ class BookMarkController_UpdateTest extends TestCase
     // use WithoutMiddleware;
 
     private $user;
+    private $bookMarkRepository;
 
     public function setup():void
     {
         parent::setUp();
         // ユーザーを用意
         $this->user = User::factory()->create();
+        $this->bookMarkRepository = new BookMarkTagRepository();
+
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'ja';
     }
 
     // 期待
@@ -60,10 +66,7 @@ class BookMarkController_UpdateTest extends TestCase
         $newTags = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag){
-            BookMarkTag::create([
-                "book_mark_id" => $bookMark->id,
-                "tag_id"     => $tag->id
-            ]);
+            $this->bookMarkRepository->store($tag->id,$bookMark->id);
         }
 
 
@@ -123,10 +126,7 @@ class BookMarkController_UpdateTest extends TestCase
         $newTags = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag){
-            BookMarkTag::create([
-                "book_mark_id" => $bookMark->id,
-                "tag_id"     => $tag->id
-            ]);
+            $this->bookMarkRepository->store($tag->id,$bookMark->id);
         }
 
         $response = $this
@@ -187,10 +187,7 @@ class BookMarkController_UpdateTest extends TestCase
         $tags    = Tag::factory()->count(4)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag){
-            BookMarkTag::create([
-                "book_mark_id" => $bookMark->id,
-                "tag_id"     => $tag->id
-            ]);
+            $this->bookMarkRepository->store($tag->id,$bookMark->id);
         }
 
         $response = $this
@@ -256,10 +253,7 @@ class BookMarkController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $bookMark->id,
-            "tag_id"     => null
-        ]);
+        $this->bookMarkRepository->store(null,$bookMark->id);
 
         $response = $this
         ->actingAs($this->user)
@@ -317,10 +311,7 @@ class BookMarkController_UpdateTest extends TestCase
         $tags    = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag){
-            BookMarkTag::create([
-                "book_mark_id" => $bookMark->id,
-                "tag_id"       => $tag->id
-            ]);
+            $this->bookMarkRepository->store($tag->id,$bookMark->id);
         }
 
         $response = $this
@@ -374,10 +365,7 @@ class BookMarkController_UpdateTest extends TestCase
         // ブックマークなどを作成
         $bookMark = BookMark::factory()->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $bookMark->id,
-            "tag_id"     => null
-        ]);
+        $this->bookMarkRepository->store(null,$bookMark->id);
 
         // 更新
         $response = $this
@@ -438,10 +426,7 @@ class BookMarkController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $bookMark->id,
-            "tag_id"     => null
-        ]);
+        $this->bookMarkRepository->store(null,$bookMark->id);
 
         // 更新
         $response = $this
@@ -511,10 +496,7 @@ class BookMarkController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(2)->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $bookMark->id,
-            "tag_id"     => null
-        ]);
+        $this->bookMarkRepository->store(null,$bookMark->id);
 
         // 更新
         $response = $this
@@ -584,10 +566,7 @@ class BookMarkController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(4)->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $bookMark->id,
-            "tag_id"     => null
-        ]);
+        $this->bookMarkRepository->store(null,$bookMark->id);
 
         // 更新
         $response = $this
@@ -665,10 +644,7 @@ class BookMarkController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(4)->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $bookMark->id,
-            "tag_id"     => $tags[0]->id
-        ]);
+        $this->bookMarkRepository->store($tags[0]->id,$bookMark->id);
 
         // 更新
         $response = $this
@@ -736,10 +712,7 @@ class BookMarkController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $bookMark->id,
-            "tag_id"       => $tags[0]->id,
-        ]);
+        $this->bookMarkRepository->store($tags[0]->id,$bookMark->id);
 
         // 更新
         $response = $this
@@ -812,10 +785,7 @@ class BookMarkController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $bookMark->id,
-            "tag_id"       => $tags[0]->id
-        ]);
+        $this->bookMarkRepository->store($tags[0]->id,$bookMark->id);
 
         // 更新
         $response = $this
@@ -888,10 +858,7 @@ class BookMarkController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(4)->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $bookMark->id,
-            "tag_id"     => $tags[0]->id
-        ]);
+        $this->bookMarkRepository->store($tags[0]->id,$bookMark->id);
 
         // 更新
         $response = $this
@@ -960,15 +927,10 @@ class BookMarkController_UpdateTest extends TestCase
         $oldBookMark = BookMark::factory()->create(['user_id' => $this->user->id]);
         $newBookMark = BookMark::factory()->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $oldBookMark->id,
-            "tag_id"       => null
-        ]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $newBookMark->id,
-            "tag_id"       => null
-        ]);
+        $this->bookMarkRepository->store(null,$oldBookMark->id);
+
+        $this->bookMarkRepository->store(null,$newBookMark->id);
 
         // 更新
         $response = $this
@@ -1000,10 +962,7 @@ class BookMarkController_UpdateTest extends TestCase
         // タグ
         $tags    = Tag::factory()->count(4)->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            "book_mark_id" => $bookMark->id,
-            "tag_id"     => $tags[0]->id
-        ]);
+        $this->bookMarkRepository->store($tags[0]->id,$bookMark->id);
 
 
         $otherUser = User::factory()->create();

--- a/tests/Feature/Controller/BookMarkTransitionControllerTest.php
+++ b/tests/Feature/Controller/BookMarkTransitionControllerTest.php
@@ -12,6 +12,8 @@ use App\Models\BookMark;
 use App\Models\BookMarkTag;
 use App\Http\Controllers\BookMarkTransitionController;
 
+use App\Repository\BookMarkTagRepository;
+
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 use Carbon\Carbon;
@@ -37,6 +39,7 @@ class BookMarkTransitionControllerTest extends TestCase
 
     private $user;
     private $controller;
+    private $bookMarkRepository;
 
     public function setup():void
     {
@@ -44,6 +47,9 @@ class BookMarkTransitionControllerTest extends TestCase
         // ユーザーを用意
         $this->user = User::factory()->create();
         $this->controller = new BookMarkTransitionController();
+        $this->bookMarkRepository = new BookMarkTagRepository();
+
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'ja';
     }
 
     public function test_transitionToEditBookMark_自分の記事_タグ登録済み()
@@ -63,10 +69,7 @@ class BookMarkTransitionControllerTest extends TestCase
         $tags = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag) {
-            BookMarkTag::create([
-                'book_mark_id' => $bookMark->id,
-                'tag_id'     => $tag->id,
-            ]);
+            $this->bookMarkRepository->store($tag->id,$bookMark->id);
         }
 
         $response = $this
@@ -94,10 +97,7 @@ class BookMarkTransitionControllerTest extends TestCase
         // タグを登録
         $tags = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
-        BookMarkTag::create([
-            'book_mark_id' => $bookMark->id,
-            'tag_id'     => null,
-        ]);
+        $this->bookMarkRepository->store(null,$bookMark->id);
 
         $response = $this
         ->actingAs($this->user)
@@ -128,10 +128,7 @@ class BookMarkTransitionControllerTest extends TestCase
         $tags = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag) {
-            BookMarkTag::create([
-                'book_mark_id' => $bookMark->id,
-                'tag_id'     => $tag->id,
-            ]);
+            $this->bookMarkRepository->store($tag->id,$bookMark->id);
         }
 
         //削除
@@ -166,10 +163,7 @@ class BookMarkTransitionControllerTest extends TestCase
         $tags = Tag::factory()->count(3)->create(['user_id' => $this->user->id]);
 
         foreach ($tags as $tag) {
-            BookMarkTag::create([
-                'book_mark_id' => $bookMark->id,
-                'tag_id'     => $tag->id,
-            ]);
+            $this->bookMarkRepository->store($tag->id,$bookMark->id);
         }
 
         $response = $this


### PR DESCRIPTION
多言語処理に使うヘッダープロパティを設定(設定しないとエラーを吐かれる)
カウントアップなどの関係でリポジトリを直接使わないとエラーがでるようになったためリポジトリを使うように修正