### PR TITLE
カウントアップダウンした時updated_atが更新されるのを防ぐ｡

### DIFF
--- a/app/Http/Controllers/ArticleTransitionController.php
+++ b/app/Http/Controllers/ArticleTransitionController.php
@@ -31,7 +31,7 @@ class ArticleTransitionController extends Controller
     //記事閲覧画面に遷移する時の処理
     public function transitionToViewArticle($articleId)
     {
-        Article::where('id','=',$articleId)->increment('count');
+        $this->articleRepository->countUp($articleId);
 
         return Inertia::render('Article/ViewArticle',[
             'article'        => $this->articleRepository->serve(articleId:$articleId),

--- a/app/Http/Controllers/BookMarkController.php
+++ b/app/Http/Controllers/BookMarkController.php
@@ -207,6 +207,6 @@ class BookMarkController extends Controller
         if ($this->bookMarkRepository->isDeleted($bookMarkId)) {return response('',400);}
 
 
-        BookMark::where('id','=',$bookMarkId)->increment('count');
+        $this->bookMarkRepository->countUp($bookMarkId);
     }
 }

--- a/app/Repository/ArticleRepository.php
+++ b/app/Repository/ArticleRepository.php
@@ -227,6 +227,17 @@ class ArticleRepository
         // false:他人のを覗こうとしている
         return ($article->user_id) == $userId;
     }
+
+    public function countUp($articleId)
+    {
+        $article = Article::where('id', $articleId)->first();
+        $article->count += 1;
+        $article->timestamps = false;
+        $article->save();
+
+        // incrementを使えば簡単だが､今回はこの動きでupdated_atが変化すると不都合が起きる
+        // Article::where('id','=',$articleId)->increment('count');
+    }
 }
 
 

--- a/app/Repository/ArticleTagRepository.php
+++ b/app/Repository/ArticleTagRepository.php
@@ -3,8 +3,9 @@ namespace App\Repository;
 
 use DB;
 use Carbon\Carbon;
+
 use App\Models\ArticleTag;
-use App\Models\Tag;
+use App\Repository\TagRepository;
 
 class ArticleTagRepository
 {
@@ -17,7 +18,7 @@ class ArticleTagRepository
         ]);
 
         //カウントアップ
-        Tag::where('id','=',$tagId)-> increment('count');
+        TagRepository::countUp($tagId);
     }
 
     //記事からはずされたタグを削除
@@ -28,7 +29,7 @@ class ArticleTagRepository
             ->delete();
 
         //カウントダウン
-        Tag::where('id','=',$tagId)-> decrement('count');
+        TagRepository::countDown($tagId);
     }
 
     //記事に紐付けられているタグを更新

--- a/app/Repository/BookMarkRepository.php
+++ b/app/Repository/BookMarkRepository.php
@@ -242,4 +242,14 @@ class BookMarkRepository
         ->whereNull('deleted_at')
         ->exists();//existsでダブっていればtrue
     }
+
+    public function countUp($bookMarkId)
+    {
+        $bookMark = BookMark::where('id', $bookMarkId)->first();
+        $bookMark->count += 1;
+        $bookMark->timestamps = false;
+        $bookMark->save();
+
+        // incrementを使えば簡単だが､今回はこの動きでupdated_atが変化すると不都合が起きる
+    }
 }

--- a/app/Repository/BookMarkTagRepository.php
+++ b/app/Repository/BookMarkTagRepository.php
@@ -5,7 +5,7 @@ use DB;
 use Carbon\Carbon;
 
 use App\Models\BookMarkTag;
-use App\Models\Tag;
+use App\Repository\TagRepository;
 
 class BookMarkTagRepository
 {
@@ -18,7 +18,7 @@ class BookMarkTagRepository
         ]);
 
         //カウントアップ
-        Tag::where('id','=',$tagId)-> increment('count');
+        TagRepository::countUp($tagId);
     }
 
     //ブックマークからはずされたタグを削除
@@ -29,7 +29,7 @@ class BookMarkTagRepository
             ->delete();
 
         //カウントダウン
-        Tag::where('id','=',$tagId)-> decrement('count');
+        TagRepository::countDown($tagId);
     }
 
     //ブックマークに紐付けられているタグを更新

--- a/app/Repository/TagRepository.php
+++ b/app/Repository/TagRepository.php
@@ -198,4 +198,19 @@ class TagRepository
         // false:他人のを覗こうとしている
         return ($tag->user_id) == $userId ;
     }
+
+    public static function countUp($tagId){
+        $tag = Tag::where('id', $tagId)->first();
+        $tag->count += 1;
+        $tag->timestamps = false;
+        $tag->save();
+    }
+
+    public static function countDown($tagId)
+    {
+        $tag = Tag::where('id', $tagId)->first();
+        $tag->count -= 1;
+        $tag->timestamps = false;
+        $tag->save();
+    }
 }


### PR DESCRIPTION
カウントアップダウンした時updated_atが更新されると
更新日順で並べた時に不都合が起こる｡
updated_atは編集などの行動を起こした時にのみに更新させたい｡

以下の時には動かしたくない
* 閲覧して閲覧数が増えた時
* タグの付け外しで､使った数の増減する時