### PR TITLE
長文で重くならないように工夫

### DIFF
--- a/resources/js/Components/article/ArticleBody.vue
+++ b/resources/js/Components/article/ArticleBody.vue
@@ -24,7 +24,6 @@
         <div v-show="activeTab === 1">
             <v-textarea
                 ref="textarea"
-                filled
                 no-resize
                 rows="20"
                 :label="messages.bodylabel"
@@ -33,7 +32,7 @@
             ></v-textarea>
         </div>
 
-        <CompiledMarkDown v-show="activeTab === -1" :originalMarkDown="body" />
+        <CompiledMarkDown ref="compiled" v-show="activeTab === -1" />
     </div>
 </template>
 
@@ -71,6 +70,8 @@ export default {
             this.activeTab *= -1;
             if (this.activeTab === 1) {
                 this.focusToBody();
+            } else {
+                this.$refs.compiled.compileMarkDown(this.body);
             }
         },
         serveBody() {

--- a/resources/js/Components/article/ArticleBody.vue
+++ b/resources/js/Components/article/ArticleBody.vue
@@ -22,14 +22,15 @@
         </div>
         <!-- md入力欄  -->
         <div v-show="activeTab === 1">
-            <v-textarea
-                ref="textarea"
-                no-resize
-                rows="20"
-                :label="messages.bodylabel"
-                v-model="body"
-                @keydown.tab.prevent.exact="addTabSpace()"
-            ></v-textarea>
+            <label for="">
+                {{ messages.bodylabel }}
+                <textarea
+                    ref="textarea"
+                    v-model="body"
+                    rows="20"
+                    @keydown.tab.prevent.exact="addTabSpace()"
+                />
+            </label>
         </div>
 
         <CompiledMarkDown ref="compiled" v-show="activeTab === -1" />
@@ -129,8 +130,11 @@ export default {
 textarea {
     width: 100%;
     resize: none;
-    // padding: 20px;
-    background-color: #f6f6f6;
+    padding: 10px;
+    background-color: #e9e9e9;
+    font-family: "Roboto", "Noto Sans" !important;
+    // いまいちしっくりこない
+    // できたらvuetifyのフォントをつかいたいので後日探す
 }
 
 .tabLabel {

--- a/resources/js/Components/article/CompiledMarkDown.vue
+++ b/resources/js/Components/article/CompiledMarkDown.vue
@@ -1,8 +1,5 @@
 <template>
-    <div
-        class="CompiledMarkDown markdown-body"
-        v-html="compileMarkDown()"
-    ></div>
+    <div class="CompiledMarkDown markdown-body" v-html="this.body"></div>
 </template>
 
 <script>
@@ -17,21 +14,21 @@ marked.setOptions({
     gfm: true,
 });
 export default {
-    props: {
-        originalMarkDown: {
-            type: String,
-            default: "",
-        },
+    data() {
+        return {
+            body: null,
+        };
     },
     methods: {
-        compileMarkDown() {
+        compileMarkDown(originalMarkDown = "") {
             // 無毒化
-            const sanitized = sanitizeHtml(this.originalMarkDown, {
+            const sanitized = sanitizeHtml(originalMarkDown, {
                 enforceHtmlBoundary: true,
             });
             const beforeCompiled = this.replaceMarkDownBefore(sanitized);
             const compiled = marked(beforeCompiled);
-            return this.replaceMarkDownAfter(compiled);
+            // return 先が変わってしまったから変数に入れるしかない
+            this.body = this.replaceMarkDownAfter(compiled);
         },
         // 変換前の処理
         replaceMarkDownBefore(arg) {
@@ -50,11 +47,14 @@ export default {
             // codeタグでは上記の<br   />を消す
             arg = arg.replace(/(?<=`[\s|\S]*)<br   \/>(?=[\s|\S]*`)/g, "");
 
+            // スペースを変換
+
+            // タブを変換
+
             return arg;
         },
         // 変換後の処理
         replaceMarkDownAfter(arg) {
-            console.log(arg);
             // <br   />の副作用でテーブルに余計な空白行が追加される
             // ので､それへの対処
             arg = arg.replace(/<tr>\s*<td><br   \/><\/td>[\s|\S]*<\/tr>/g, "");

--- a/resources/js/Pages/Article/ViewArticle.vue
+++ b/resources/js/Pages/Article/ViewArticle.vue
@@ -34,7 +34,7 @@
             <h1 class="title">{{ article.title }}</h1>
 
             <!-- md表示 -->
-            <CompiledMarkDown :originalMarkDown="article.body" />
+            <CompiledMarkDown ref="compiled" />
 
             <loadingDialog />
         </div>
@@ -118,6 +118,10 @@ export default {
         document.addEventListener("keydown", this.keyEvents);
 
         this.$store.commit("setGlobalLoading", false);
+
+        // 変換したマークダウンを表示させとく
+        this.$refs.compiled.compileMarkDown(this.article.body);
+
         this.$nextTick(function () {
             if (this.$store.state.lang == "ja") {
                 this.messages = this.japanese;

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,58 +1,68 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-    <head prefix="og: https://ogp.me/ns#">
-        {{-- ogpを使うには必要 --}}
-        <meta charset="utf-8">
 
-        {{-- レスポンシブデザインに必要らしい --}}
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+<head prefix="og: https://ogp.me/ns#">
+    {{-- ogpを使うには必要 --}}
+    <meta charset="utf-8">
 
-        {{-- seo対策 --}}
-        {{-- 一部直接書かないとエラーを図れるかも --}}
+    {{-- レスポンシブデザインに必要らしい --}}
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {{-- seo対策 --}}
+    {{-- 一部直接書かないとエラーを図れるかも --}}
 
 
 
-        {!! \App\Tools\MetaToolKit::render() !!}
+    {!! \App\Tools\MetaToolKit::render() !!}
 
-        {{--  --}}
+    {{--  --}}
 
-        {{-- csrf対策? --}}
-        <meta name="csrf-token" content="{{ csrf_token() }}">
+    {{-- csrf対策? --}}
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <!-- Fonts -->
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
+    <!-- Fonts -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
-        {{-- icon --}}
-        <link rel="icon" type="image/png" href="/favicon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Mochiy+Pop+One&display=swap" rel="stylesheet">
 
-        <!-- Scripts -->
-        @inertiaHead
-        @routes
-        @vite('resources/js/app.js')
+    {{-- icon --}}
+    <link rel="icon" type="image/png" href="/favicon.png">
 
-        {{-- google広告 --}}
-        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6551381289717615"
-     crossorigin="anonymous"></script>
-        {{-- googleに見つけてもらう --}}
-        <meta name="google-site-verification" content="ero83E0pFy6Cmszzqy2IoKzSt-oFYzsg6hqXfemz0MM" />
+    <!-- Scripts -->
+    @inertiaHead
+    @routes
+    @vite('resources/js/app.js')
 
-        {{-- google analytics --}}
-        <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-JHN6733DMV"></script>
-        <script>
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
+    {{-- google広告 --}}
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6551381289717615"
+        crossorigin="anonymous"></script>
+    {{-- googleに見つけてもらう --}}
+    <meta name="google-site-verification" content="ero83E0pFy6Cmszzqy2IoKzSt-oFYzsg6hqXfemz0MM" />
 
-          gtag('config', 'G-JHN6733DMV');
-        </script>
-    </head>
-    <style>
-        /* #app {
+    {{-- google analytics --}}
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JHN6733DMV"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+
+        function gtag() {
+            dataLayer.push(arguments);
+        }
+        gtag('js', new Date());
+
+        gtag('config', 'G-JHN6733DMV');
+    </script>
+</head>
+<style>
+    /* #app {
             height: 100vh;
         } */
-    </style>
-    <body class="font-sans antialiased">
-        @inertia
-    </body>
+</style>
+
+<body class="font-sans antialiased">
+    @inertia
+</body>
+
 </html>


### PR DESCRIPTION
# 1. 長文を書いているときに､改行､記号付をしていると重くなるので処理の仕方を変更｡

## before
文は専用のコンポーネントにpropsで渡していた
-> 頻繁にpropsが変更されたことにより重くなったと思われる

## after
変換ボタンをおしたら､コンポーネントの変換関数に文を渡すようにした

# 2. 改行をするとき､文章が強制的に動くのでvuetifyをやめて素のtextareaを使うように変更
vuetifyのv-textareaを使っていたのだが､改行をすると強制的に改行した文が一番上に行く｡
-> この動きは使いづらくなるので｡素のtextareaを使うようにした